### PR TITLE
Fix bug impacting font on certain machines

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,7 +37,7 @@ module.exports = {
       },
       fontFamily: {
         mono: ['var(--font-code)', ...fontFamily.mono],
-        sans: ['Inter', ...fontFamily.sans],
+        sans: ['var(--font-inter)', ...fontFamily.sans],
       },
       colors: {
         primary: colors.blue,


### PR DESCRIPTION
Seemed some machines did not link the string Inter and needed the specific font variable to be named. This should fix the animation text.